### PR TITLE
Add GitHub Actions workflow for Java CI with Gradle

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,23 @@
+name: Java CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+    - name: Build with Gradle
+      run: ./gradlew build --no-daemon
+    - name: Run tests
+      run: ./gradlew test --no-daemon


### PR DESCRIPTION
This pull request (PR) introduces a GitHub Actions workflow named "Java CI" to automate the build and test processes for a Java project using Gradle.

**Workflow Summary:**

**Triggers:**  
The workflow is triggered by pushes and pull requests directed towards the main branch.

**Environment:**  
It runs on the latest Ubuntu environment (ubuntu-latest).

**Steps:**

1. **Checkout Code:** Utilizes the `actions/checkout@v3` action to retrieve the repository code.
2. **Set Up Java:** Configures JDK 21 (using the Temurin distribution) with `actions/setup-java@v3`.
3. **Build Project:** Executes `./gradlew build --no-daemon` to build the project using Gradle.
4. **Run Tests:** Runs `./gradlew test --no-daemon` to execute the project's tests.

**Purpose:**  
The workflow automates the building and testing of the Java project on every push or pull request to the main branch, helping to ensure code quality and identify issues early.